### PR TITLE
🔎 Fix for invisible search criteria

### DIFF
--- a/dracula.css
+++ b/dracula.css
@@ -237,6 +237,10 @@ input {
   color: var(--body-color-muted) !important;
 }
 
+#chat .message-search input {
+  color: var(--body-bg-color);
+}
+
 .channel-list-item[data-type=channel]::before,
 .context-menu-chan::before {
   content: "\f086";


### PR DESCRIPTION
The search box had white on white, your typed criteria was essentially invisible.
![Screenshot 2023-01-04 at 20 42 45](https://user-images.githubusercontent.com/1727812/210647357-4f081d81-6b53-43a0-9a54-e820a9e58b9e.png)

I have updated the color of the search input.
![Screenshot 2023-01-04 at 20 44 04](https://user-images.githubusercontent.com/1727812/210647540-25a12e88-00cc-4386-9a81-175c92eac5b0.png)
